### PR TITLE
Add Content-Type header explicitly when uploading

### DIFF
--- a/tools/update_stats.dart
+++ b/tools/update_stats.dart
@@ -57,9 +57,12 @@ Future<void> main() async {
 }
 
 void uploadFiles() {
-  Process.run('/usr/bin/aws', ['s3', 'cp', '/tmp/data/',
-    's3://blaseball-status/data/', '--include="*.json"',
-    '--recursive', '--acl=public-read']).then((ProcessResult results) {
+  Process.run('/usr/bin/aws', [
+      's3', 'cp', '/tmp/data/',
+      's3://blaseball-status/data/'
+      '--include="*.json"', '--recursive',
+      '--acl=public-read', "--content-type='application/json; charset=utf-8'"
+  ]).then((ProcessResult results) {
     print(results.stdout);
     print(results.stderr);
   });


### PR DESCRIPTION
This fixes the Unicode encoding issue caused by Dart's broken unicode support (https://github.com/dart-lang/http/issues/186)

![image](https://user-images.githubusercontent.com/233815/110045642-fb13d480-7d18-11eb-9b08-e472fe756d24.png)


Note: I haven't tested this, since I don't have a Dart development environment, so you should probably do that before merging 😅 